### PR TITLE
[fix] value null in config

### DIFF
--- a/lib/Configuration.ts
+++ b/lib/Configuration.ts
@@ -34,7 +34,8 @@ export class Configuration extends Map<any, any> {
       Object.entries(tree).forEach(([k, v]) => {
         // if (typeof v === 'object' && v !== null) {
         if (
-          v instanceof Object
+          v !== null
+          && v instanceof Object
           && typeof v !== 'function'
         ) {
           // If value is an array, flatten by index and don't try to flatten further
@@ -163,7 +164,8 @@ export class Configuration extends Map<any, any> {
    */
   private _flattenSet(key, value) {
     if (
-      value instanceof Object
+      value !== null
+      && value instanceof Object
       && typeof value !== 'function'
       && !Array.isArray(value)
     ) {
@@ -202,7 +204,10 @@ export class Configuration extends Map<any, any> {
       }
       // If configAction is set to merge, it will default values over the initial config
       else if (hasKey && configAction === 'merge') {
-        if (Array.isArray(value)) {
+        if (value === null) {
+          // Do Nothing
+        }
+        else if (Array.isArray(value)) {
           // Do Nothing
         }
         else if (typeof value === 'number') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrix/fabrix",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrix/fabrix",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Strongly Typed Modern Web Application Framework for Node.js",
   "keywords": [
     "framework",

--- a/test/integration/fabrixapp.test.js
+++ b/test/integration/fabrixapp.test.js
@@ -159,6 +159,23 @@ describe('Fabrix', () => {
           })
         })
 
+        it('should be able to reassign a previously null value', () => {
+          const def = {
+            pkg: { },
+            api: { },
+            config: {
+              main: {
+                spools: [ Testspool ]
+              },
+              test: {
+                prefix: '/api'
+              }
+            }
+          }
+          const app = new FabrixApp(def)
+          assert.equal(app.config.get('test.prefix'), '/api')
+        })
+
         it('should disallow re-assignment of config object', () => {
           const def = {
             pkg: { },

--- a/test/integration/testapp.js
+++ b/test/integration/testapp.js
@@ -7,7 +7,8 @@ module.exports = {
   },
   config: {
     test: {
-      val: 1
+      val: 1,
+      prefix: '/api'
     },
     main: {
       paths: {

--- a/test/integration/testspool.js
+++ b/test/integration/testspool.js
@@ -11,7 +11,8 @@ module.exports = class Testspool extends Spool {
         test: {
           val: 0,
           array: [3, 4, 5],
-          otherval: 1
+          otherval: 1,
+          prefix: null
         }
       },
       api: {

--- a/test/lib/Configuration.test.js
+++ b/test/lib/Configuration.test.js
@@ -72,7 +72,8 @@ describe('lib.Configuration', () => {
         array: [1, 2, 3],
         subobj: {
           attr: 'a'
-        }
+        },
+        nullValue: null
       }
     }
   })
@@ -245,6 +246,19 @@ describe('lib.Configuration', () => {
       beforeEach(() => {
         config = new lib.Configuration(_.cloneDeep(testConfig))
       })
+      it('should set leaves as well as root', () => {
+
+        config.set('test', null)
+        assert.equal(config.get('test'), null)
+        config.set('test', 'word')
+        assert.equal(config.get('test'), 'word')
+      })
+
+      it('should set leaves as well as root on a previously null value', () => {
+        config.set('customerObject.nullValue', 'word')
+        assert.equal(config.get('customerObject.nullValue'), 'word')
+      })
+
       it('should set leaves as well as root', () => {
 
         config.set('test', {test2: {test3: 4}})


### PR DESCRIPTION
#### Description
Checks config values for null values so they are not converted to objects.

#### Issues
- Config values that were null and are replaced by a string will result in a string instead of an object. (Gitter Channel)
