### PR TITLE
feat(loggerProxy): Out of the box confiuration of logger events with …

### DIFF
--- a/lib/LoggerProxy.ts
+++ b/lib/LoggerProxy.ts
@@ -40,11 +40,14 @@ import { FabrixGeneric } from './common/Generic'
 
 export class LoggerProxy extends FabrixGeneric {
   public app: FabrixApp
-  public warn
-  public debug
-  public info
   public error
+  public warn
+  public info
+  public debug
   public silly
+
+  public levelHierarchy = ['silly', 'debug', 'info', 'warn', 'error']
+
   /**
    * Instantiate Proxy; bind log events to default console.log
    */
@@ -79,7 +82,11 @@ export class LoggerProxy extends FabrixGeneric {
    * Emit fabrix:log, pass the "level" parameter to the event handler as the
    * first argument.
    */
-  emitLogEvent (level: string) {
-    return (...msg: any[]) => this.app.emit('fabrix:log', level, msg)
+  emitLogEvent (level: string, current: string = 'silly') {
+    const currentLevel = this.app && this.app.config ? this.app.config.get('log.level') || current : current
+    level = level || current
+
+    const log = this.levelHierarchy.indexOf(currentLevel) <= this.levelHierarchy.indexOf(level) ? 'fabrix:log' : 'fabrix:log:ignored'
+    return (...msg: any[]) => this.app.emit(log, level, msg)
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrix/fabrix",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Strongly Typed Modern Web Application Framework for Node.js",
   "keywords": [
     "framework",

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -34,6 +34,9 @@ const App = {
         testdir: path.resolve(__dirname, 'testdir')
       }
     },
+    log: {
+      level: 'silly'
+    },
     i18n: {
       lng: 'en',
       resources: {

--- a/test/integration/testapp.js
+++ b/test/integration/testapp.js
@@ -19,6 +19,7 @@ module.exports = {
       ]
     },
     log: {
+      level: 'info',
       logger: new smokesignals.Logger('silent')
     }
   },

--- a/test/lib/LoggerProxy.test.js
+++ b/test/lib/LoggerProxy.test.js
@@ -21,6 +21,20 @@ describe('lib.LoggerProxy', () => {
     })
     logger.silly('hello')
   })
+  it('should emit fabrix:log:ignored with level=info on invocation of log.silly', done => {
+    emitter.once('fabrix:log:ignored', level => {
+      assert.equal(level, 'silly')
+      done()
+    })
+    emitter.emit('fabrix:log:ignored', 'silly', 'hello')
+  })
+  it('should emit fabrix:log:ignored with level=info on invocation of log.silly', done => {
+
+    emitter.once('fabrix:log:ignored', emitLogEvent => {
+      done()
+    })
+    logger.emitLogEvent('silly', 'info')('hello')
+  })
   it('should emit fabrix:log with level=debug on invocation of log.debug', done => {
     emitter.once('fabrix:log', level => {
       assert.equal(level, 'debug')

--- a/test/lib/common/spools/Spool.test.js
+++ b/test/lib/common/spools/Spool.test.js
@@ -43,6 +43,19 @@ describe('spool', () => {
       spool.log('info', 'hello from spool')
     })
   })
+
+  describe('#log silent', () => {
+    it('is a convenience method that simply invokes app.log', done => {
+      const spool= new Testspool(app)
+
+      app.once('fabrix:log:ignored', (level, [ msg ]) => {
+        done()
+      })
+
+      spool.log('silly', 'hello ignored from spool')
+    })
+  })
+
   describe('#app', () => {
     it('is a convenience method that should show the app', () => {
       const app = new Fabrix(testApp)


### PR DESCRIPTION
…out a logger spool

#### Description
set listeners on config.log.level, emits a `fabrix:log:ignored` if level is not higher than set level

#### Issues
- resolves none
